### PR TITLE
Fix subscribe to events when host is not 127.0.0.1

### DIFF
--- a/src/Client/WebSocket/AbstractWebSocketClient.php
+++ b/src/Client/WebSocket/AbstractWebSocketClient.php
@@ -79,7 +79,9 @@ abstract class AbstractWebSocketClient implements WebSocketClientInterface
             $ariApplicationsClient = new Applications(
                 new RestClientSettings(
                     $webSocketClientSettings->getUser(),
-                    $webSocketClientSettings->getPassword()
+                    $webSocketClientSettings->getPassword(),
+                    $webSocketClientSettings->getHost(),
+                    $webSocketClientSettings->getPort()
                 )
             );
         }


### PR DESCRIPTION
If asterisk is running on remote host, subscribe to events fails. This pull request fix this behaviour.